### PR TITLE
Revert "Legge til modia.adeo.no som ingresss"

### DIFF
--- a/nais/dev-fss/default.json
+++ b/nais/dev-fss/default.json
@@ -7,7 +7,6 @@
     "https://dittnav-eventer-modia.nais.preprod.local",
     "https://app-q0.adeo.no/dittnav-eventer-modia",
     "https://app-q1.adeo.no/dittnav-eventer-modia",
-    "https://modia-q0.dev.adeo.no/dittnav-eventer-modia",
-    "https://modia-q1.dev.adeo.no/dittnav-eventer-modia"
+    "https://app-q6.adeo.no/dittnav-eventer-modia"
   ]
 }

--- a/nais/dev-fss/personbruker.json
+++ b/nais/dev-fss/personbruker.json
@@ -7,7 +7,6 @@
     "https://dittnav-eventer-modia.nais.preprod.local",
     "https://app-q0.adeo.no/dittnav-eventer-modia",
     "https://app-q1.adeo.no/dittnav-eventer-modia",
-    "https://modia-q0.dev.adeo.no/dittnav-eventer-modia",
-    "https://modia-q1.dev.adeo.no/dittnav-eventer-modia"
+    "https://app-q6.adeo.no/dittnav-eventer-modia"
   ]
 }

--- a/nais/prod-fss/default.json
+++ b/nais/prod-fss/default.json
@@ -4,7 +4,6 @@
   "environment": "prod",
   "ingresses": [
     "https://dittnav-eventer-modia.nais.adeo.no",
-    "https://app.adeo.no/dittnav-eventer-modia",
-    "https://modia.adeo.no/dittnav-eventer-modia"
+    "https://app.adeo.no/dittnav-eventer-modia"
   ]
 }

--- a/nais/prod-fss/personbruker.json
+++ b/nais/prod-fss/personbruker.json
@@ -4,7 +4,6 @@
   "environment": "prod",
   "ingresses": [
     "https://dittnav-eventer-modia.nais.adeo.no",
-    "https://app.adeo.no/dittnav-eventer-modia",
-    "https://modia.adeo.no/dittnav-eventer-modia"
+    "https://app.adeo.no/dittnav-eventer-modia"
   ]
 }


### PR DESCRIPTION
This reverts commit eb661b47

For å få innlogging til å fungere som ønsket i modia ble vi nødt til å endre cookie navn.
Denne endringen er derfor ikke nødvendig.
